### PR TITLE
fix webgl warning

### DIFF
--- a/aether.h
+++ b/aether.h
@@ -26605,7 +26605,8 @@ void GraphicsDevice::Initialize( class Window* window )
 	EmscriptenWebGLContextAttributes attrs;
 	emscripten_webgl_init_context_attributes( &attrs );
 	attrs.alpha = 0;
-	attrs.majorVersion = ae::GLMajorVersion;
+	// webGL 2 maps to OpenGL 3
+	attrs.majorVersion = 2;
 	attrs.minorVersion = ae::GLMinorVersion;
 	m_context = emscripten_webgl_create_context( "canvas", &attrs );
 	AE_ASSERT( m_context > 0 );


### PR DESCRIPTION
Fixes warning that appears in web builds. Init configuration for `_AE_EMSCRIPTEN_` tries to set the value to 3 which isn't valid. It should be 2 because this value represents the WebGL version, not the OpenGL version.

### Issue


<img width="1680" height="630" alt="Screenshot 2026-05-14 at 10 39 22 PM" src="https://github.com/user-attachments/assets/8cd8c7ce-bbb7-4dc9-8bb7-6439aedc31b8" />

### Source Docs

WebGL2 maps to OpenGL3
https://registry.khronos.org/webgl/specs/latest/2.0/


EMS generated JS where the error is logged from, confirms only version 1 and 2 are options.


<img width="810" height="188" alt="Screenshot 2026-05-14 at 10 32 26 PM" src="https://github.com/user-attachments/assets/25f5fb2c-cc1a-49d0-b796-dc389af480f7" />

[EMS Docs](https://emscripten.org/docs/api_reference/html5.h.html#c.EmscriptenWebGLContextAttributes.majorVersion) also show 1 & 2 as valid values

### Result

No error logs :)

<img width="1677" height="508" alt="Screenshot 2026-05-14 at 10 38 13 PM" src="https://github.com/user-attachments/assets/0b4f1ff3-58cb-4e7b-b6ab-d7c7a68383a4" />

